### PR TITLE
Plugged RecordURLSession into wiretapp

### DIFF
--- a/demo.wiretapp/MockResponses/WireTappUITests/ExampleTest/:todos/1.json
+++ b/demo.wiretapp/MockResponses/WireTappUITests/ExampleTest/:todos/1.json
@@ -1,0 +1,23 @@
+{
+    "status": 200,
+    "response": [
+        {
+          "userId": 1,
+          "id": 1,
+          "title": "Nick Gorman",
+          "completed": false
+        },
+        {
+          "userId": 1,
+          "id": 2,
+          "title": "Muhammad Ali",
+          "completed": false
+        },
+        {
+          "userId": 1,
+          "id": 3,
+          "title": "Md Rashidul",
+          "completed": false
+        }
+     ]
+}

--- a/demo.wiretapp/demo.wiretapp.xcodeproj/project.pbxproj
+++ b/demo.wiretapp/demo.wiretapp.xcodeproj/project.pbxproj
@@ -7,13 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7E1D2A5E2743572C00594E2C /* Wiretapp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2AFCBF274353CA003A115D /* Wiretapp.swift */; };
 		7E1D2A61274497CC00594E2C /* WiretappSessionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1D2A60274497CC00594E2C /* WiretappSessionError.swift */; };
-		7E1D2A6227449D2500594E2C /* WiretappSessionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1D2A60274497CC00594E2C /* WiretappSessionError.swift */; };
 		7E1D2A6427449F8800594E2C /* WiretappRecordURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1D2A6327449F8800594E2C /* WiretappRecordURLProtocol.swift */; };
 		7E1D2A662747445100594E2C /* CustomURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1D2A652747445100594E2C /* CustomURLProtocol.swift */; };
 		7E2AFCBD274173A0003A115D /* WiretappBaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2AFCBC274173A0003A115D /* WiretappBaseTestCase.swift */; };
-		7E2AFCBE27417444003A115D /* WiretappURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168C76627401FCC00EE0136 /* WiretappURLProtocol.swift */; };
 		7E2AFCC0274353CA003A115D /* Wiretapp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2AFCBF274353CA003A115D /* Wiretapp.swift */; };
 		C168C73C27401CDF00EE0136 /* demo_wiretappApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168C73B27401CDF00EE0136 /* demo_wiretappApp.swift */; };
 		C168C73E27401CDF00EE0136 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168C73D27401CDF00EE0136 /* ContentView.swift */; };
@@ -318,11 +315,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7E2AFCBE27417444003A115D /* WiretappURLProtocol.swift in Sources */,
-				7E1D2A5E2743572C00594E2C /* Wiretapp.swift in Sources */,
 				7E2AFCBD274173A0003A115D /* WiretappBaseTestCase.swift in Sources */,
 				C168C75927401CE400EE0136 /* demo_wiretappUITests.swift in Sources */,
-				7E1D2A6227449D2500594E2C /* WiretappSessionError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/demo.wiretapp/demo.wiretapp.xcodeproj/xcshareddata/xcschemes/demo.wiretapp.xcscheme
+++ b/demo.wiretapp/demo.wiretapp.xcodeproj/xcshareddata/xcschemes/demo.wiretapp.xcscheme
@@ -70,6 +70,18 @@
             ReferencedContainer = "container:demo.wiretapp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "wiretappRecording"
+            value = "true"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "mock_responses"
+            value = "file://$(SOURCE_ROOT)/MockResponses/recorded"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/demo.wiretapp/demo.wiretapp/ContentView.swift
+++ b/demo.wiretapp/demo.wiretapp/ContentView.swift
@@ -15,25 +15,27 @@ struct ContentView: View {
 
     var body: some View {
         VStack {
-            Text(message)
-                .padding()
-                .onTapGesture {
-                    self.cancellable = networkService.get(
-                        url: URL(string: "https://jsonplaceholder.typicode.com/todos")!,
-                        modelType: [Todo].self
-                    )
-                    .receive(on: DispatchQueue.main)
-                    .sink {
-                        print($0)
-                    } receiveValue: {
-                        todos = $0
+            ScrollView {
+                Text(message)
+                    .padding()
+                    .onTapGesture {
+                        self.cancellable = networkService.get(
+                            url: URL(string: "https://jsonplaceholder.typicode.com/todos")!,
+                            modelType: [Todo].self
+                        )
+                        .receive(on: DispatchQueue.main)
+                        .sink {
+                            print($0)
+                        } receiveValue: {
+                            todos = $0
+                        }
                     }
-                }
-            LazyVStack {
-                ForEach(todos, id: \.title)  { todo in
-                    VStack {
-                        Text(todo.title)
-                        Text(String(todo.completed))
+                LazyVStack {
+                    ForEach(todos, id: \.title)  { todo in
+                        VStack {
+                            Text(todo.title)
+                            Text(String(todo.completed))
+                        }
                     }
                 }
             }

--- a/demo.wiretapp/demo.wiretapp/NetworkService.swift
+++ b/demo.wiretapp/demo.wiretapp/NetworkService.swift
@@ -3,13 +3,15 @@ import Foundation
 
 class NetworkService {
     let baseURL: String
+    let urlSession: URLSession
 
-    init(baseURL: String) {
+    init(baseURL: String, urlSession: URLSession = .shared) {
         self.baseURL = baseURL
+        self.urlSession = urlSession
     }
 
     func get<Response: Decodable>(url: URL, modelType: Response.Type) -> AnyPublisher<Response, Error> {
-        URLSession.shared
+        urlSession
             .dataTaskPublisher(
                 for: URLRequest(url: url)
             )

--- a/demo.wiretapp/demo.wiretapp/Wiretapp/Wiretapp.swift
+++ b/demo.wiretapp/demo.wiretapp/Wiretapp/Wiretapp.swift
@@ -5,15 +5,9 @@ public class Wiretapp {
     public static let testCasePath: String = "testCasePath"
 
     public class func configure() {
-        if let
-            recordingEnabled = ProcessInfo.processInfo.environment[recordEnabled],
-            recordingEnabled == "true"
-        {
-            //URLProtocol.registerClass(RecordURLProtocol.self)
-        } else if
-            ProcessInfo.processInfo.environment[testCasePath] != nil
-        {
-            URLProtocol.registerClass(WiretappURLProtocol.self)
-        }
+        // The last registered class gets called first [Muhammad U. Ali]
+        // when a request is dispatched using URLSession.shared
+        URLProtocol.registerClass(WiretappRecordURLProtocol.self)
+        URLProtocol.registerClass(WiretappURLProtocol.self)
     }
 }

--- a/demo.wiretapp/demo.wiretapp/Wiretapp/Wiretapp.swift
+++ b/demo.wiretapp/demo.wiretapp/Wiretapp/Wiretapp.swift
@@ -4,10 +4,15 @@ public class Wiretapp {
     public static let recordEnabled: String = "wiretappRecording"
     public static let testCasePath: String = "testCasePath"
 
-    public class func configure() {
+    public class func register() {
         // The last registered class gets called first [Muhammad U. Ali]
         // when a request is dispatched using URLSession.shared
         URLProtocol.registerClass(WiretappRecordURLProtocol.self)
         URLProtocol.registerClass(WiretappURLProtocol.self)
+    }
+
+    public class func register(configuration: URLSessionConfiguration) -> URLSessionConfiguration {
+        configuration.protocolClasses = [WiretappRecordURLProtocol.self, WiretappURLProtocol.self]
+        return configuration
     }
 }

--- a/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappRecordURLProtocol.swift
+++ b/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappRecordURLProtocol.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 public class WiretappRecordURLProtocol: URLProtocol {
     typealias Output = (data: Data, response: URLResponse)
     var urlCounter: [String: Int] = [:]
@@ -8,12 +9,17 @@ public class WiretappRecordURLProtocol: URLProtocol {
     }
 
     public override class func canInit(with request: URLRequest) -> Bool {
-        return true
+        if let
+            recordingEnabled = ProcessInfo.processInfo.environment[Wiretapp.recordEnabled],
+            recordingEnabled == "true"
+        {
+            return true
+        }
+        return false
     }
 
     public override func startLoading() {
-        self.
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+        URLSession(configuration: .ephemeral).dataTask(with: request) { [weak self] data, response, error in
             if
                 let data = data,
                 let response = response,
@@ -63,6 +69,7 @@ public class WiretappRecordURLProtocol: URLProtocol {
                 }
             }
         }
+        .resume()
     }
     func createFolder(url: URL) throws {
         if !FileManager.default.fileExists(atPath: url.path) {

--- a/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappRecordURLProtocol.swift
+++ b/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappRecordURLProtocol.swift
@@ -1,8 +1,8 @@
 import Foundation
 
+private var urlCounter: [String: Int] = [:]
 public class WiretappRecordURLProtocol: URLProtocol {
     typealias Output = (data: Data, response: URLResponse)
-    var urlCounter: [String: Int] = [:]
     let recordPath: String = ""
     public override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
@@ -37,10 +37,10 @@ public class WiretappRecordURLProtocol: URLProtocol {
                     let filename = self.request.url?.path.fileName,
                     let docURL = URL(string: responsePath)
                 {
-                    self.urlCounter[filename, default: -1] += 1
+                    urlCounter[filename, default: -1] += 1
                     var timesRecorded = 0
 
-                    if let urlCount = self.urlCounter[filename] {
+                    if let urlCount = urlCounter[filename] {
                         timesRecorded = urlCount
                     }
 

--- a/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappURLProtocol.swift
+++ b/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappURLProtocol.swift
@@ -1,8 +1,9 @@
 import Foundation
 
+private var urlCounter: [String: Int] = [:]
+
 public class WiretappURLProtocol: URLProtocol {
     typealias Output = (data: Data, response: URLResponse)
-    public var urlCounter: [String: Int] = [:]
     public override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }

--- a/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappURLProtocol.swift
+++ b/demo.wiretapp/demo.wiretapp/Wiretapp/WiretappURLProtocol.swift
@@ -8,7 +8,7 @@ public class WiretappURLProtocol: URLProtocol {
     }
 
     public override class func canInit(with request: URLRequest) -> Bool {
-        return true
+        ProcessInfo.processInfo.environment[Wiretapp.testCasePath] != nil
     }
 
     public override func startLoading() {

--- a/demo.wiretapp/demo.wiretapp/demo_wiretappApp.swift
+++ b/demo.wiretapp/demo.wiretapp/demo_wiretappApp.swift
@@ -2,14 +2,22 @@ import SwiftUI
 
 @main
 struct demo_wiretappApp: App {
-    var body: some Scene {
-        setup()
-        return WindowGroup {
-            ContentView(networkService: NetworkService(baseURL: "https://google.com"))
-        }
+    let urlSession: URLSession!
+
+    init() {
+        var config = URLSessionConfiguration.default
+        config = Wiretapp.register(configuration: config)
+        self.urlSession = URLSession(configuration: config)
     }
 
-    func setup() {
-        Wiretapp.configure()
+    var body: some Scene {
+        return WindowGroup {
+            ContentView(
+                networkService: NetworkService(
+                    baseURL: "https://google.com",
+                    urlSession: urlSession
+                )
+            )
+        }
     }
 }

--- a/demo.wiretapp/demo.wiretappUITests/WiretappBaseTestCase.swift
+++ b/demo.wiretapp/demo.wiretappUITests/WiretappBaseTestCase.swift
@@ -9,7 +9,7 @@ class WiretappBaseTestCase: XCTestCase {
         app = XCUIApplication()
         if let mockResponses = getRootPath() {
             app.launchEnvironment = [
-                Wiretapp.testCasePath: mockResponses + "/MockResponses/" + name.createDirectoryPath()
+                "testCasePath": mockResponses + "/MockResponses/" + name.createDirectoryPath()
             ]
             print(mockResponses + name.createDirectoryPath())
         }

--- a/demo.wiretapp/demo.wiretappUITests/demo_wiretappUITests.swift
+++ b/demo.wiretapp/demo.wiretappUITests/demo_wiretappUITests.swift
@@ -8,5 +8,12 @@ class WireTappUITests: WiretappBaseTestCase {
         
         app.staticTexts["delectus aut autem"]
             .wait(until: \.exists)
+
+        app.staticTexts["Hello, world!"]
+            .wait(until: \.isHittable)
+            .tap()
+
+        app.staticTexts["Nick Gorman"]
+            .wait(until: \.exists)
     }
 }


### PR DESCRIPTION
- Plugged in the RecordURLSession implementation
- Removed the package file membership (Wiretapp, WiretappURLProtocol, WiretappSessionError) from the UITest target
- Moved conditionals to switch between Record and Mock modes into the canInit methods of the classes
- Temporarily added mock_responses environment variable to direct the recorded files

![demo](https://user-images.githubusercontent.com/22680294/142732593-32a575f3-e62e-4272-aceb-36a3d5d9a38a.gif)


